### PR TITLE
Implement emergency safety handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.pio
 /.vscode/c_cpp_properties.json
 /.vscode/launch.json
+__pycache__/
+*.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /.vscode/launch.json
 __pycache__/
 *.py[cod]
+/build/
+/install/
+/log/

--- a/README.md
+++ b/README.md
@@ -106,3 +106,15 @@ If you have an access to the Pico's UART0 directly on your host machine run:
 ```bash
 make agent MICRO_ROS_DEVICE=/dev/ttyAMA0
 ```
+
+## Hardware-in-the-loop tests
+
+The emergency feature has an interactive ROS 2 hardware test for real OpenMower hardware.
+Run it with flashed firmware and a running micro-ROS agent:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+python3 test/hil/emergency_interactive.py
+```
+
+The test guides the operator through pressing STOP, activating one lift sensor, and activating two lift sensors. It verifies the published emergency topics and the three-message command confirmation rule.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ More details about this firmware can be found in [documentation](https://jkaflik
 - [x] Charging
 - [x] LED status
 - [x] IMU
-- [ ] Emergency mode
-  - [ ] Emergency publisher
-  - [ ] Emergency restart service
+- [x] Emergency mode
+  - [x] Emergency publishers
+  - [x] Latched emergency command topic
 - [ ] Cover panel support
 
 ## Usage
@@ -31,8 +31,35 @@ The firmware uses onboard NeoPixel LED(s) to display the current system status. 
 - **Magenta**: Battery discharging
 - **Red**: Battery low
 - **Blue**: IMU sensor failure
+- **Blinking red**: Emergency latch active
 
 When multiple statuses are active, each status will be shown for approximately 800ms with a 200ms black separator between them. The sequence will continue to cycle through all active statuses.
+Emergency has priority over the normal status sequence and is shown as a blinking red LED.
+
+### Emergency ROS API
+
+Emergency state is published at 10 Hz:
+
+| Topic | Type | Description |
+| --- | --- | --- |
+| `emergency/active` | `std_msgs/msg/Bool` | Emergency latch is active. |
+| `emergency/stop_active` | `std_msgs/msg/Bool` | Stop input is active after debounce. |
+| `emergency/lift_active` | `std_msgs/msg/Bool` | Lift emergency is active. |
+| `emergency/tilt_active` | `std_msgs/msg/Bool` | Tilt emergency is active. |
+| `emergency/software_requested` | `std_msgs/msg/Bool` | Emergency was requested by ROS. |
+| `emergency/release_blocked` | `std_msgs/msg/Bool` | Release is blocked by an active physical input. |
+| `emergency/lifted_wheels` | `std_msgs/msg/UInt8` | Number of active lift inputs. |
+
+Commands are accepted on `emergency/command` as `std_msgs/msg/Bool`:
+
+| Value | Meaning |
+| --- | --- |
+| `true` | Request/latch emergency. |
+| `false` | Request emergency release. |
+
+The same command value must be received three times within one second before it is accepted.
+Release requests are ignored while any physical stop/lift/tilt input is active.
+The emergency latch starts active after boot and must be released explicitly.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Commands are accepted on `emergency/command` as `std_msgs/msg/Bool`:
 
 The same command value must be received three times within one second before it is accepted.
 Release requests are ignored while any physical stop/lift/tilt input is active.
-The emergency latch starts active after boot and must be released explicitly.
+The emergency latch starts inactive after boot when physical inputs are clear.
+Physical stop/lift/tilt inputs and `emergency/command=true` latch emergency explicitly.
 
 ## Build
 
@@ -126,4 +127,4 @@ python3 test/hil/emergency_interactive.py
 ```
 
 The test guides the operator through pressing STOP, activating one lift sensor, and activating two lift sensors. It verifies the published emergency status and the three-message command confirmation rule.
-The test is rerunnable on the same firmware boot; if the emergency latch was released by a previous run, the script reports that state and re-latches before continuing.
+The test is rerunnable on the same firmware boot; if the emergency latch is inactive at the start, the script reports that expected state and latches before checks that require an active latch.

--- a/README.md
+++ b/README.md
@@ -42,13 +42,19 @@ Emergency state is published at 10 Hz:
 
 | Topic | Type | Description |
 | --- | --- | --- |
-| `emergency/active` | `std_msgs/msg/Bool` | Emergency latch is active. |
-| `emergency/stop_active` | `std_msgs/msg/Bool` | Stop input is active after debounce. |
-| `emergency/lift_active` | `std_msgs/msg/Bool` | Lift emergency is active. |
-| `emergency/tilt_active` | `std_msgs/msg/Bool` | Tilt emergency is active. |
-| `emergency/software_requested` | `std_msgs/msg/Bool` | Emergency was requested by ROS. |
-| `emergency/release_blocked` | `std_msgs/msg/Bool` | Release is blocked by an active physical input. |
-| `emergency/lifted_wheels` | `std_msgs/msg/UInt8` | Number of active lift inputs. |
+| `emergency/status` | `omros2_firmware_msgs/msg/EmergencyStatus` | Combined emergency status. |
+
+`EmergencyStatus` fields:
+
+| Field | Description |
+| --- | --- |
+| `active` | Emergency latch is active. |
+| `stop_active` | Stop input is active after debounce. |
+| `lift_active` | Lift emergency is active. |
+| `tilt_active` | Tilt emergency is active. |
+| `software_requested` | Emergency was requested by ROS. |
+| `release_blocked` | Release is blocked by an active physical input. |
+| `lifted_wheels` | Number of active lift inputs. |
 
 Commands are accepted on `emergency/command` as `std_msgs/msg/Bool`:
 
@@ -114,7 +120,10 @@ Run it with flashed firmware and a running micro-ROS agent:
 
 ```bash
 source /opt/ros/jazzy/setup.bash
+colcon build --base-paths extra_packages --build-base build/hil --install-base install/hil
+source install/hil/setup.bash
 python3 test/hil/emergency_interactive.py
 ```
 
-The test guides the operator through pressing STOP, activating one lift sensor, and activating two lift sensors. It verifies the published emergency topics and the three-message command confirmation rule.
+The test guides the operator through pressing STOP, activating one lift sensor, and activating two lift sensors. It verifies the published emergency status and the three-message command confirmation rule.
+The test is rerunnable on the same firmware boot; if the emergency latch was released by a previous run, the script reports that state and re-latches before continuing.

--- a/extra_packages/omros2_firmware_msgs/CMakeLists.txt
+++ b/extra_packages/omros2_firmware_msgs/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.5)
+project(omros2_firmware_msgs)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/EmergencyStatus.msg"
+)
+
+ament_package()

--- a/extra_packages/omros2_firmware_msgs/msg/EmergencyStatus.msg
+++ b/extra_packages/omros2_firmware_msgs/msg/EmergencyStatus.msg
@@ -1,0 +1,7 @@
+bool active
+bool stop_active
+bool lift_active
+bool tilt_active
+bool software_requested
+bool release_blocked
+uint8 lifted_wheels

--- a/extra_packages/omros2_firmware_msgs/package.xml
+++ b/extra_packages/omros2_firmware_msgs/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>omros2_firmware_msgs</name>
+  <version>0.0.0</version>
+  <description>ROS interfaces for omros2-firmware.</description>
+  <maintainer email="jkaflik@users.noreply.github.com">jkaflik</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/microros.meta
+++ b/microros.meta
@@ -1,0 +1,11 @@
+{
+  "names": {
+    "rmw_microxrcedds": {
+      "cmake-args": [
+        "-DRMW_UXRCE_ENTITY_CREATION_TIMEOUT=5000",
+        "-DRMW_UXRCE_ENTITY_DESTROY_TIMEOUT=1000",
+        "-DRMW_UXRCE_MAX_PUBLISHERS=16"
+      ]
+    }
+  }
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,3 +30,4 @@ lib_deps =
 build_flags = ${env.build_flags} -DHW_0_13_X -DPIO_FRAMEWORK_ARDUINO_NO_USB -DRMW_UXRCE_ENTITY_CREATION_DESTROY_TIMEOUT=0 -DUCLIENT_MAX_SESSION_CONNECTION_ATTEMPTS=3
 board_microros_distro = jazzy
 board_microros_transport = serial
+board_microros_user_meta = microros.meta

--- a/src/emergency.cpp
+++ b/src/emergency.cpp
@@ -1,0 +1,190 @@
+#include "emergency.h"
+
+#include <pico/mutex.h>
+
+#include "pins.h"
+
+namespace emergency
+{
+
+namespace
+{
+constexpr unsigned long STOP_DEBOUNCE_MS = 20;
+constexpr unsigned long LIFT_PERIOD_MS = 100;
+constexpr unsigned long TILT_PERIOD_MS = 2500;
+constexpr unsigned long COMMAND_WINDOW_MS = 1000;
+constexpr uint8_t COMMAND_CONFIRMATIONS_REQUIRED = 3;
+
+auto_init_mutex(emergency_mutex);
+
+bool latch_active = true;
+bool stop_active = false;
+bool lift_active = false;
+bool tilt_active = false;
+bool software_requested = false;
+bool release_blocked = false;
+uint8_t lifted_wheels = 0;
+
+bool raw_stop_active = false;
+bool raw_lift_input_active = false;
+
+unsigned long stop_started_ms = 0;
+unsigned long lift_started_ms = 0;
+unsigned long tilt_started_ms = 0;
+
+bool command_pending = false;
+bool pending_command = false;
+uint8_t pending_command_count = 0;
+unsigned long pending_command_started_ms = 0;
+
+bool isActiveLowInput(uint8_t pin)
+{
+  return digitalRead(pin) == LOW;
+}
+
+bool elapsedSinceStart(bool condition,
+                       unsigned long& started_ms,
+                       unsigned long threshold_ms,
+                       unsigned long now)
+{
+  if (!condition)
+  {
+    started_ms = 0;
+    return false;
+  }
+
+  if (started_ms == 0)
+  {
+    started_ms = now;
+    return false;
+  }
+
+  return now - started_ms >= threshold_ms;
+}
+
+bool physicalInputPresent()
+{
+  return raw_stop_active || raw_lift_input_active;
+}
+
+void updateUnlocked()
+{
+  const unsigned long now = millis();
+
+  lifted_wheels = 0;
+  if (isActiveLowInput(PIN_EMERGENCY_1))
+  {
+    lifted_wheels++;
+  }
+  if (isActiveLowInput(PIN_EMERGENCY_2))
+  {
+    lifted_wheels++;
+  }
+
+  raw_lift_input_active = lifted_wheels > 0;
+  raw_stop_active = isActiveLowInput(PIN_EMERGENCY_3) || isActiveLowInput(PIN_EMERGENCY_4);
+
+  stop_active = elapsedSinceStart(raw_stop_active, stop_started_ms, STOP_DEBOUNCE_MS, now);
+  lift_active = elapsedSinceStart(lifted_wheels >= 2, lift_started_ms, LIFT_PERIOD_MS, now);
+  tilt_active = elapsedSinceStart(raw_lift_input_active, tilt_started_ms, TILT_PERIOD_MS, now);
+
+  if (stop_active || lift_active || tilt_active)
+  {
+    latch_active = true;
+  }
+
+  release_blocked = latch_active && physicalInputPresent();
+}
+
+void requestLatch()
+{
+  software_requested = true;
+  latch_active = true;
+}
+
+void requestRelease()
+{
+  updateUnlocked();
+
+  if (physicalInputPresent())
+  {
+    release_blocked = true;
+    return;
+  }
+
+  latch_active = false;
+  software_requested = false;
+  release_blocked = false;
+}
+
+}  // namespace
+
+void init()
+{
+  pinMode(PIN_EMERGENCY_1, INPUT);
+  pinMode(PIN_EMERGENCY_2, INPUT);
+  pinMode(PIN_EMERGENCY_3, INPUT);
+  pinMode(PIN_EMERGENCY_4, INPUT);
+}
+
+void update()
+{
+  mutex_enter_blocking(&emergency_mutex);
+  updateUnlocked();
+  mutex_exit(&emergency_mutex);
+}
+
+void handleCommand(bool latch_requested)
+{
+  mutex_enter_blocking(&emergency_mutex);
+
+  const unsigned long now = millis();
+
+  if (!command_pending || pending_command != latch_requested
+      || now - pending_command_started_ms > COMMAND_WINDOW_MS)
+  {
+    command_pending = true;
+    pending_command = latch_requested;
+    pending_command_count = 1;
+    pending_command_started_ms = now;
+    mutex_exit(&emergency_mutex);
+    return;
+  }
+
+  pending_command_count++;
+  if (pending_command_count < COMMAND_CONFIRMATIONS_REQUIRED)
+  {
+    mutex_exit(&emergency_mutex);
+    return;
+  }
+
+  command_pending = false;
+  pending_command_count = 0;
+
+  if (latch_requested)
+  {
+    requestLatch();
+  }
+  else
+  {
+    requestRelease();
+  }
+
+  mutex_exit(&emergency_mutex);
+}
+
+State getState()
+{
+  mutex_enter_blocking(&emergency_mutex);
+  State state = {latch_active,
+                 stop_active,
+                 lift_active,
+                 tilt_active,
+                 software_requested,
+                 release_blocked,
+                 lifted_wheels};
+  mutex_exit(&emergency_mutex);
+  return state;
+}
+
+}  // namespace emergency

--- a/src/emergency.cpp
+++ b/src/emergency.cpp
@@ -17,7 +17,7 @@ constexpr uint8_t COMMAND_CONFIRMATIONS_REQUIRED = 3;
 
 auto_init_mutex(emergency_mutex);
 
-bool latch_active = true;
+bool latch_active = false;
 bool stop_active = false;
 bool lift_active = false;
 bool tilt_active = false;

--- a/src/emergency.h
+++ b/src/emergency.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <Arduino.h>
+
+namespace emergency
+{
+
+struct State
+{
+  bool active;
+  bool stop_active;
+  bool lift_active;
+  bool tilt_active;
+  bool software_requested;
+  bool release_blocked;
+  uint8_t lifted_wheels;
+};
+
+void init();
+void update();
+void handleCommand(bool latch_requested);
+State getState();
+
+}  // namespace emergency

--- a/src/led_status.hpp
+++ b/src/led_status.hpp
@@ -13,6 +13,7 @@ enum LedStatusFlag
   LED_STATUS_DISCHARGING = (1 << 2),
   LED_STATUS_BATTERY_LOW = (1 << 3),
   LED_STATUS_IMU_FAILED = (1 << 4),
+  LED_STATUS_EMERGENCY = (1 << 5),
 };
 
 struct StatusColor
@@ -130,6 +131,12 @@ public:
 
     std::vector<LedStatusFlag> activeStatuses = getActiveStatuses();
 
+    if (getFlag(LED_STATUS_EMERGENCY))
+    {
+      setColor(255, 0, 0, true);
+      return;
+    }
+
     // with no active statuses, turn off the LED
     if (activeStatuses.empty())
     {
@@ -178,6 +185,7 @@ private:
     statusColorMap.push_back({LED_STATUS_DISCHARGING, {255, 0, 255}});  // Magenta for discharging
     statusColorMap.push_back({LED_STATUS_BATTERY_LOW, {255, 0, 0}});    // Red for battery low
     statusColorMap.push_back({LED_STATUS_IMU_FAILED, {0, 0, 255}});     // Blue for IMU failed
+    statusColorMap.push_back({LED_STATUS_EMERGENCY, {255, 0, 0}});      // Red blink for emergency
   }
 
   std::vector<LedStatusFlag> getActiveStatuses() const

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,10 @@
 #include <std_msgs/msg/bool.h>
 #include <std_msgs/msg/float32.h>
-#include <std_msgs/msg/u_int8.h>
 
 #include <Arduino.h>
 #include <EMA.h>
 #include <micro_ros_platformio.h>
+#include <omros2_firmware_msgs/msg/emergency_status.h>
 #include <rcl/rcl.h>
 #include <rclc/executor.h>
 #include <rclc/rclc.h>
@@ -142,9 +142,6 @@ void setup1()
 
   support = new uros::Support();
   auto node = new uros::Node(*support, "openmower_mainboard");
-  auto randomNumberPublisher = new uros::Publisher<std_msgs__msg__Float32>(
-    *node, "random_number", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32));
-
   auto imuPublisher = new uros::Publisher<sensor_msgs__msg__Imu>(
     *node, "imu/data_raw", UROS_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, Imu));
   auto imuTimer = new uros::Timer(*node,
@@ -171,44 +168,36 @@ void setup1()
 
   auto batteryStatePublisher = new uros::Publisher<sensor_msgs__msg__BatteryState>(
     *node, "power", UROS_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, BatteryState));
-  auto batteryStateTimer = new uros::Timer(*node,
-                                           1000,
-                                           [batteryStatePublisher]()
-                                           {
-                                             auto& msg = batteryStatePublisher->get_message();
-
-                                             auto ns = rmw_uros_epoch_nanos();
-                                             msg.header.stamp.sec = ns / 1000000000;
-                                             msg.header.stamp.nanosec = ns % 1000000000;
-                                             msg.voltage = batteryVoltage;
-                                             msg.charge = chargeCurrent;
-                                             msg.percentage = batteryPercentage;
-                                             msg.present = batteryPresent;
-                                             msg.power_supply_status = powerSupplyStatus;
-                                             msg.power_supply_health = powerSupplyHealth;
-
-                                             batteryStatePublisher->publish();
-                                           });
   auto chargeVoltagePublisher = new uros::Publisher<std_msgs__msg__Float32>(
     *node, "power/charge_voltage", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32));
-  auto chargeVoltageTimer = new uros::Timer(*node,
-                                            1000,
-                                            [chargeVoltagePublisher]()
-                                            {
-                                              auto& msg = chargeVoltagePublisher->get_message();
-                                              msg.data = chargeVoltage;
-                                              chargeVoltagePublisher->publish();
-                                            });
   auto chargerPresentPublisher = new uros::Publisher<std_msgs__msg__Bool>(
     *node, "power/charger_present", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
-  auto chargerPresentTimer = new uros::Timer(*node,
-                                             1000,
-                                             [chargerPresentPublisher]()
-                                             {
-                                               auto& msg = chargerPresentPublisher->get_message();
-                                               msg.data = isChargerPresent;
-                                               chargerPresentPublisher->publish();
-                                             });
+  auto powerTimer = new uros::Timer(
+    *node,
+    1000,
+    [batteryStatePublisher, chargeVoltagePublisher, chargerPresentPublisher]()
+    {
+      auto& batteryMsg = batteryStatePublisher->get_message();
+
+      auto ns = rmw_uros_epoch_nanos();
+      batteryMsg.header.stamp.sec = ns / 1000000000;
+      batteryMsg.header.stamp.nanosec = ns % 1000000000;
+      batteryMsg.voltage = batteryVoltage;
+      batteryMsg.charge = chargeCurrent;
+      batteryMsg.percentage = batteryPercentage;
+      batteryMsg.present = batteryPresent;
+      batteryMsg.power_supply_status = powerSupplyStatus;
+      batteryMsg.power_supply_health = powerSupplyHealth;
+      batteryStatePublisher->publish();
+
+      auto& chargeVoltageMsg = chargeVoltagePublisher->get_message();
+      chargeVoltageMsg.data = chargeVoltage;
+      chargeVoltagePublisher->publish();
+
+      auto& chargerPresentMsg = chargerPresentPublisher->get_message();
+      chargerPresentMsg.data = isChargerPresent;
+      chargerPresentPublisher->publish();
+    });
 
   auto emergencyCommandSubscription = new uros::Subscriber<std_msgs__msg__Bool>(
     *node,
@@ -216,50 +205,26 @@ void setup1()
     UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool),
     [](const std_msgs__msg__Bool& msg) { emergency::handleCommand(msg.data); });
 
-  auto emergencyActivePublisher = new uros::Publisher<std_msgs__msg__Bool>(
-    *node, "emergency/active", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
-  auto emergencyStopPublisher = new uros::Publisher<std_msgs__msg__Bool>(
-    *node, "emergency/stop_active", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
-  auto emergencyLiftPublisher = new uros::Publisher<std_msgs__msg__Bool>(
-    *node, "emergency/lift_active", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
-  auto emergencyTiltPublisher = new uros::Publisher<std_msgs__msg__Bool>(
-    *node, "emergency/tilt_active", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
-  auto emergencySoftwarePublisher = new uros::Publisher<std_msgs__msg__Bool>(
-    *node, "emergency/software_requested", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
-  auto emergencyReleaseBlockedPublisher = new uros::Publisher<std_msgs__msg__Bool>(
-    *node, "emergency/release_blocked", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
-  auto emergencyLiftedWheelsPublisher = new uros::Publisher<std_msgs__msg__UInt8>(
-    *node, "emergency/lifted_wheels", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, UInt8));
+  auto emergencyStatusPublisher = new uros::Publisher<omros2_firmware_msgs__msg__EmergencyStatus>(
+    *node,
+    "emergency/status",
+    UROS_GET_MSG_TYPE_SUPPORT(omros2_firmware_msgs, msg, EmergencyStatus));
   auto emergencyTimer = new uros::Timer(
     *node,
     100,
-    [emergencyActivePublisher,
-     emergencyStopPublisher,
-     emergencyLiftPublisher,
-     emergencyTiltPublisher,
-     emergencySoftwarePublisher,
-     emergencyReleaseBlockedPublisher,
-     emergencyLiftedWheelsPublisher]()
+    [emergencyStatusPublisher]()
     {
       auto state = emergency::getState();
+      auto& msg = emergencyStatusPublisher->get_message();
 
-      auto publishBool = [](uros::Publisher<std_msgs__msg__Bool>* publisher, bool value)
-      {
-        auto& msg = publisher->get_message();
-        msg.data = value;
-        publisher->publish();
-      };
-
-      publishBool(emergencyActivePublisher, state.active);
-      publishBool(emergencyStopPublisher, state.stop_active);
-      publishBool(emergencyLiftPublisher, state.lift_active);
-      publishBool(emergencyTiltPublisher, state.tilt_active);
-      publishBool(emergencySoftwarePublisher, state.software_requested);
-      publishBool(emergencyReleaseBlockedPublisher, state.release_blocked);
-
-      auto& liftedWheelsMsg = emergencyLiftedWheelsPublisher->get_message();
-      liftedWheelsMsg.data = state.lifted_wheels;
-      emergencyLiftedWheelsPublisher->publish();
+      msg.active = state.active;
+      msg.stop_active = state.stop_active;
+      msg.lift_active = state.lift_active;
+      msg.tilt_active = state.tilt_active;
+      msg.software_requested = state.software_requested;
+      msg.release_blocked = state.release_blocked;
+      msg.lifted_wheels = state.lifted_wheels;
+      emergencyStatusPublisher->publish();
     });
 
   isSecondCoreSetupDone = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <std_msgs/msg/bool.h>
 #include <std_msgs/msg/float32.h>
+#include <std_msgs/msg/u_int8.h>
 
 #include <Arduino.h>
 #include <EMA.h>
@@ -10,6 +11,7 @@
 #include <sensor_msgs/msg/battery_state.h>
 #include <sensor_msgs/msg/imu.h>
 
+#include "emergency.h"
 #include "hardware.h"
 #include "imu.h"
 #include "led_status.hpp"
@@ -208,6 +210,58 @@ void setup1()
                                                chargerPresentPublisher->publish();
                                              });
 
+  auto emergencyCommandSubscription = new uros::Subscriber<std_msgs__msg__Bool>(
+    *node,
+    "emergency/command",
+    UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool),
+    [](const std_msgs__msg__Bool& msg) { emergency::handleCommand(msg.data); });
+
+  auto emergencyActivePublisher = new uros::Publisher<std_msgs__msg__Bool>(
+    *node, "emergency/active", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
+  auto emergencyStopPublisher = new uros::Publisher<std_msgs__msg__Bool>(
+    *node, "emergency/stop_active", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
+  auto emergencyLiftPublisher = new uros::Publisher<std_msgs__msg__Bool>(
+    *node, "emergency/lift_active", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
+  auto emergencyTiltPublisher = new uros::Publisher<std_msgs__msg__Bool>(
+    *node, "emergency/tilt_active", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
+  auto emergencySoftwarePublisher = new uros::Publisher<std_msgs__msg__Bool>(
+    *node, "emergency/software_requested", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
+  auto emergencyReleaseBlockedPublisher = new uros::Publisher<std_msgs__msg__Bool>(
+    *node, "emergency/release_blocked", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool));
+  auto emergencyLiftedWheelsPublisher = new uros::Publisher<std_msgs__msg__UInt8>(
+    *node, "emergency/lifted_wheels", UROS_GET_MSG_TYPE_SUPPORT(std_msgs, msg, UInt8));
+  auto emergencyTimer = new uros::Timer(
+    *node,
+    100,
+    [emergencyActivePublisher,
+     emergencyStopPublisher,
+     emergencyLiftPublisher,
+     emergencyTiltPublisher,
+     emergencySoftwarePublisher,
+     emergencyReleaseBlockedPublisher,
+     emergencyLiftedWheelsPublisher]()
+    {
+      auto state = emergency::getState();
+
+      auto publishBool = [](uros::Publisher<std_msgs__msg__Bool>* publisher, bool value)
+      {
+        auto& msg = publisher->get_message();
+        msg.data = value;
+        publisher->publish();
+      };
+
+      publishBool(emergencyActivePublisher, state.active);
+      publishBool(emergencyStopPublisher, state.stop_active);
+      publishBool(emergencyLiftPublisher, state.lift_active);
+      publishBool(emergencyTiltPublisher, state.tilt_active);
+      publishBool(emergencySoftwarePublisher, state.software_requested);
+      publishBool(emergencyReleaseBlockedPublisher, state.release_blocked);
+
+      auto& liftedWheelsMsg = emergencyLiftedWheelsPublisher->get_message();
+      liftedWheelsMsg.data = state.lifted_wheels;
+      emergencyLiftedWheelsPublisher->publish();
+    });
+
   isSecondCoreSetupDone = true;
 }
 
@@ -216,6 +270,7 @@ void loop1()
   support->spin();
 
   ledStatus.setFlag(LED_STATUS_ROS_CONNECTED, support->get_state() == uros::State::AGENT_CONNECTED);
+  ledStatus.setFlag(LED_STATUS_EMERGENCY, emergency::getState().active);
 
   delay(10);  // Small delay to prevent tight loop
 }
@@ -227,9 +282,13 @@ void setup()
   pinMode(LED_BUILTIN, OUTPUT);
   pinMode(PIN_RASPI_POWER, OUTPUT);
   pinMode(PIN_ENABLE_CHARGE, OUTPUT);
+  pinMode(PIN_ESC_SHUTDOWN, OUTPUT);
 
   digitalWrite(PIN_RASPI_POWER, HIGH);
   digitalWrite(PIN_ENABLE_CHARGE, LOW);
+  digitalWrite(PIN_ESC_SHUTDOWN, LOW);
+
+  emergency::init();
 
   ledStatus.init(PIN_NEOPIXEL, 1);
   ledStatus.setColor(0, 0, 0, false);  // reset
@@ -246,9 +305,11 @@ void loop()
 {
   while (!isSecondCoreSetupDone)
   {
+    emergency::update();
     delay(10);
   }
 
+  emergency::update();
   ledStatus.update();
   chargingLoop();
 

--- a/src/ros.cpp
+++ b/src/ros.cpp
@@ -5,6 +5,7 @@
 
 #include <unordered_map>
 static std::unordered_map<const rcl_timer_t*, void*> timer_user_data;
+static std::unordered_map<const void*, void*> subscription_user_data;
 
 namespace uros
 {
@@ -36,7 +37,7 @@ bool Support::initialize_entities()
   RCCHECK(rclc_support_init(&support_, 0, NULL, &allocator_));
 
   executor_ = rclc_executor_get_zero_initialized_executor();
-  RCCHECK(rclc_executor_init(&executor_, &support_.context, 10, &allocator_));
+  RCCHECK(rclc_executor_init(&executor_, &support_.context, 16, &allocator_));
 
   for (auto* node : nodes_)
   {
@@ -246,6 +247,55 @@ void PublisherBase::cleanup()
   }
 }
 
+void* SubscriptionBase::get_subscription_user_ptr(const void* message_ptr)
+{
+  auto it = subscription_user_data.find(message_ptr);
+  if (it != subscription_user_data.end())
+  {
+    return it->second;
+  }
+  return nullptr;
+}
+
+void SubscriptionBase::set_subscription_user_ptr(const void* message_ptr, void* user_ptr)
+{
+  subscription_user_data[message_ptr] = user_ptr;
+}
+
+void SubscriptionBase::clear_subscription_user_ptr(const void* message_ptr)
+{
+  subscription_user_data.erase(message_ptr);
+}
+
+void SubscriptionBase::cleanup()
+{
+  if (initialized_)
+  {
+    rcl_ret_t ret = rcl_subscription_fini(&subscription_, node_.get_handle());
+    (void)ret;
+
+    if (message_ptr_ != nullptr)
+    {
+      clear_subscription_user_ptr(message_ptr_);
+      message_ptr_ = nullptr;
+    }
+
+    initialized_ = false;
+  }
+}
+
+SubscriptionBase::SubscriptionBase(Node& node, const char* topic_name)
+  : node_(node), topic_name_(topic_name), initialized_(false), message_ptr_(nullptr)
+{
+  subscription_ = rcl_get_zero_initialized_subscription();
+  node.add_subscription(this);
+}
+
+SubscriptionBase::~SubscriptionBase()
+{
+  cleanup();
+}
+
 PublisherBase::PublisherBase(Node& node, const char* topic_name)
   : node_(node), topic_name_(topic_name), initialized_(false)
 {
@@ -280,6 +330,12 @@ Node::~Node()
     delete publisher;
   }
   publishers_.clear();
+
+  for (auto* subscription : subscriptions_)
+  {
+    delete subscription;
+  }
+  subscriptions_.clear();
 }
 
 void Node::cleanup()
@@ -294,6 +350,11 @@ void Node::cleanup()
     for (auto* timer : timers_)
     {
       timer->cleanup();
+    }
+
+    for (auto* subscription : subscriptions_)
+    {
+      subscription->cleanup();
     }
 
     rcl_ret_t ret = rcl_node_fini(&node_);
@@ -359,6 +420,32 @@ bool Node::initialize_publishers()
   return success;
 }
 
+void Node::add_subscription(SubscriptionBase* subscription)
+{
+  subscriptions_.push_back(subscription);
+
+  if (initialized_)
+  {
+    subscription->initialize();
+  }
+}
+
+bool Node::initialize_subscriptions()
+{
+  if (!initialized_)
+  {
+    return false;
+  }
+
+  bool success = true;
+  for (auto* subscription : subscriptions_)
+  {
+    success &= subscription->initialize();
+  }
+
+  return success;
+}
+
 bool Node::initialize()
 {
   if (initialized_)
@@ -379,8 +466,9 @@ bool Node::initialize()
 
   bool timers_ok = initialize_timers();
   bool publishers_ok = initialize_publishers();
+  bool subscriptions_ok = initialize_subscriptions();
 
-  return timers_ok && publishers_ok;
+  return timers_ok && publishers_ok && subscriptions_ok;
 }
 
 }  // namespace uros

--- a/src/ros.cpp
+++ b/src/ros.cpp
@@ -221,12 +221,21 @@ bool Timer::initialize()
     return false;
   }
 
-  set_timer_user_ptr(&timer_, this);
-
   ret = rclc_executor_add_timer(node_.get_support().get_executor(), &timer_);
-  initialized_ = (ret == RCL_RET_OK);
+  if (ret != RCL_RET_OK)
+  {
+    rcl_ret_t timer_ret = rcl_timer_fini(&timer_);
+    (void)timer_ret;
+    rcl_ret_t clock_ret = rcl_clock_fini(clock_);
+    (void)clock_ret;
+    delete clock_;
+    clock_ = nullptr;
+    return false;
+  }
 
-  return initialized_;
+  set_timer_user_ptr(&timer_, this);
+  initialized_ = true;
+  return true;
 }
 
 void Timer::callback()

--- a/src/ros.h
+++ b/src/ros.h
@@ -5,6 +5,7 @@
 #include <rclc/executor.h>
 #include <rclc/rclc.h>
 
+#include <cstring>
 #include <functional>
 #include <string>
 #include <vector>
@@ -55,6 +56,7 @@ enum class State
 class Node;
 class TimerBase;
 class PublisherBase;
+class SubscriptionBase;
 
 /**
  * @brief Support class that manages ROS 2 resources for microROS.
@@ -169,6 +171,36 @@ protected:
   friend class Support;
 };
 
+class SubscriptionBase
+{
+public:
+  SubscriptionBase(Node& node, const char* topic_name);
+  virtual ~SubscriptionBase();
+
+  virtual bool initialize() = 0;
+  virtual void callback(const void* msgin) = 0;
+  bool is_initialized() const
+  {
+    return initialized_;
+  }
+
+  void cleanup();
+
+  static void* get_subscription_user_ptr(const void* message_ptr);
+  static void set_subscription_user_ptr(const void* message_ptr, void* user_ptr);
+  static void clear_subscription_user_ptr(const void* message_ptr);
+
+protected:
+  Node& node_;
+  std::string topic_name_;
+  bool initialized_;
+  rcl_subscription_t subscription_;
+  const void* message_ptr_;
+
+  friend class Node;
+  friend class Support;
+};
+
 /**
  * @brief A ROS2 Node implementation.
  *
@@ -203,6 +235,12 @@ public:
   // Initialize publishers if node is ready
   bool initialize_publishers();
 
+  // Add a subscription to this node
+  void add_subscription(SubscriptionBase* subscription);
+
+  // Initialize subscriptions if node is ready
+  bool initialize_subscriptions();
+
   // Cleanup node resources
   void cleanup();
 
@@ -220,9 +258,11 @@ private:
   bool initialized_;
   std::vector<TimerBase*> timers_;
   std::vector<PublisherBase*> publishers_;
+  std::vector<SubscriptionBase*> subscriptions_;
 
   friend class Support;
   friend class TimerBase;
+  friend class SubscriptionBase;
 };
 
 /**
@@ -326,6 +366,93 @@ public:
 private:
   MessageT message_;
   const rosidl_message_type_support_t* type_support_;
+  rmw_qos_profile_t qos_profile_;
+};
+
+template <typename MessageT>
+class Subscriber : public SubscriptionBase
+{
+public:
+  using CallbackType = std::function<void(const MessageT&)>;
+
+  Subscriber(Node& node,
+             const char* topic_name,
+             const rosidl_message_type_support_t* type_support,
+             CallbackType callback,
+             const rmw_qos_profile_t& qos_profile = rmw_qos_profile_default)
+    : SubscriptionBase(node, topic_name),
+      type_support_(type_support),
+      callback_(callback),
+      qos_profile_(qos_profile)
+  {
+    subscription_ = rcl_get_zero_initialized_subscription();
+    memset(&message_, 0, sizeof(MessageT));
+  }
+
+  ~Subscriber() override
+  {
+    cleanup();
+  }
+
+  bool initialize() override
+  {
+    if (!node_.is_initialized() || initialized_)
+    {
+      return false;
+    }
+
+    rcl_subscription_options_t sub_opts = rcl_subscription_get_default_options();
+    sub_opts.qos = qos_profile_;
+
+    rcl_ret_t ret = rcl_subscription_init(
+      &subscription_, node_.get_handle(), type_support_, topic_name_.c_str(), &sub_opts);
+    if (ret != RCL_RET_OK)
+    {
+      return false;
+    }
+
+    message_ptr_ = &message_;
+    set_subscription_user_ptr(message_ptr_, this);
+
+    ret = rclc_executor_add_subscription(node_.get_support().get_executor(),
+                                         &subscription_,
+                                         &message_,
+                                         subscription_callback,
+                                         ON_NEW_DATA);
+    if (ret != RCL_RET_OK)
+    {
+      clear_subscription_user_ptr(message_ptr_);
+      message_ptr_ = nullptr;
+      rcl_ret_t fini_ret = rcl_subscription_fini(&subscription_, node_.get_handle());
+      (void)fini_ret;
+      return false;
+    }
+
+    initialized_ = true;
+    return true;
+  }
+
+  void callback(const void* msgin) override
+  {
+    if (callback_ && msgin != nullptr)
+    {
+      callback_(*static_cast<const MessageT*>(msgin));
+    }
+  }
+
+private:
+  static void subscription_callback(const void* msgin)
+  {
+    auto* subscription_obj = static_cast<SubscriptionBase*>(get_subscription_user_ptr(msgin));
+    if (subscription_obj != nullptr)
+    {
+      subscription_obj->callback(msgin);
+    }
+  }
+
+  MessageT message_;
+  const rosidl_message_type_support_t* type_support_;
+  CallbackType callback_;
   rmw_qos_profile_t qos_profile_;
 };
 

--- a/test/hil/emergency_interactive.py
+++ b/test/hil/emergency_interactive.py
@@ -9,18 +9,72 @@ verifies the ROS 2 emergency API exposed by the firmware.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import time
 from dataclasses import dataclass
 from typing import Callable, Optional
 
 import rclpy
+from omros2_firmware_msgs.msg import EmergencyStatus
 from rclpy.node import Node
-from std_msgs.msg import Bool, UInt8
+from std_msgs.msg import Bool
+
+
+COLOR_ENABLED = False
+COLOR_CODES = {
+    "bold": "\033[1m",
+    "dim": "\033[2m",
+    "red": "\033[31m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+    "blue": "\033[34m",
+    "cyan": "\033[36m",
+    "reset": "\033[0m",
+}
 
 
 class TestFailure(RuntimeError):
     pass
+
+
+def configure_color(mode: str) -> None:
+    global COLOR_ENABLED
+
+    if mode == "never":
+        COLOR_ENABLED = False
+    elif mode == "always":
+        COLOR_ENABLED = True
+    else:
+        COLOR_ENABLED = "NO_COLOR" not in os.environ and sys.stdout.isatty()
+
+
+def colorize(text: str, *styles: str) -> str:
+    if not COLOR_ENABLED:
+        return text
+
+    prefix = "".join(COLOR_CODES[style] for style in styles)
+    return f"{prefix}{text}{COLOR_CODES['reset']}"
+
+
+def log_pass(description: str, state: Optional["EmergencySnapshot"] = None) -> None:
+    print(f"{colorize('PASS', 'green', 'bold')}: {description}")
+    if state is not None:
+        print(colorize(f"      {state.format()}", "dim"))
+
+
+def log_info(message: str) -> None:
+    print(colorize(message, "cyan"))
+
+
+def log_warn(message: str, state: Optional["EmergencySnapshot"] = None) -> None:
+    print(f"{colorize('WARN', 'yellow', 'bold')}: {message}")
+    if state is not None:
+        print(colorize(f"      {state.format()}", "dim"))
+
+
+def log_fail(message: str) -> None:
+    print(f"\n{colorize('FAIL', 'red', 'bold')}: {message}")
 
 
 @dataclass
@@ -63,27 +117,18 @@ class EmergencyProbe(Node):
         self.command_interval = command_interval
         self._subscriptions = []
         self.command_publisher = self.create_publisher(Bool, "emergency/command", 10)
-
-        self._subscribe_bool("emergency/active", "active")
-        self._subscribe_bool("emergency/stop_active", "stop_active")
-        self._subscribe_bool("emergency/lift_active", "lift_active")
-        self._subscribe_bool("emergency/tilt_active", "tilt_active")
-        self._subscribe_bool("emergency/software_requested", "software_requested")
-        self._subscribe_bool("emergency/release_blocked", "release_blocked")
         self._subscriptions.append(
-            self.create_subscription(UInt8, "emergency/lifted_wheels", self._lifted_wheels_cb, 10)
+            self.create_subscription(EmergencyStatus, "emergency/status", self._status_cb, 10)
         )
 
-    def _subscribe_bool(self, topic: str, field: str) -> None:
-        self._subscriptions.append(
-            self.create_subscription(Bool, topic, lambda msg, field=field: self._set(field, msg.data), 10)
-        )
-
-    def _lifted_wheels_cb(self, msg: UInt8) -> None:
-        self.snapshot.lifted_wheels = int(msg.data)
-
-    def _set(self, field: str, value: bool) -> None:
-        setattr(self.snapshot, field, bool(value))
+    def _status_cb(self, msg: EmergencyStatus) -> None:
+        self.snapshot.active = bool(msg.active)
+        self.snapshot.stop_active = bool(msg.stop_active)
+        self.snapshot.lift_active = bool(msg.lift_active)
+        self.snapshot.tilt_active = bool(msg.tilt_active)
+        self.snapshot.software_requested = bool(msg.software_requested)
+        self.snapshot.release_blocked = bool(msg.release_blocked)
+        self.snapshot.lifted_wheels = int(msg.lifted_wheels)
 
     def spin_for(self, duration: float) -> None:
         deadline = time.monotonic() + duration
@@ -100,21 +145,20 @@ class EmergencyProbe(Node):
         while time.monotonic() < deadline:
             rclpy.spin_once(self, timeout_sec=0.05)
             if predicate(self.snapshot):
-                print(f"PASS: {description}")
-                print(f"      {self.snapshot.format()}")
+                log_pass(description, self.snapshot)
                 return self.snapshot
 
         raise TestFailure(f"Timeout waiting for {description}. Last state: {self.snapshot.format()}")
 
     def wait_for_initial_messages(self, timeout: float) -> None:
-        self.wait_for(lambda state: state.is_complete(), timeout, "all emergency topics")
+        self.wait_for(lambda state: state.is_complete(), timeout, "emergency status topic")
 
     def wait_for_command_subscriber(self, timeout: float) -> None:
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             rclpy.spin_once(self, timeout_sec=0.05)
             if self.command_publisher.get_subscription_count() > 0:
-                print("PASS: emergency command subscriber discovered")
+                log_pass("emergency command subscriber discovered")
                 return
 
         raise TestFailure("No subscriber discovered for emergency/command")
@@ -122,7 +166,7 @@ class EmergencyProbe(Node):
     def send_command(self, value: bool, count: int = 3) -> None:
         msg = Bool()
         msg.data = value
-        print(f"Publishing emergency/command={value} {count} time(s)")
+        log_info(f"Publishing emergency/command={value} {count} time(s)")
         for _ in range(count):
             self.command_publisher.publish(msg)
             self.spin_for(self.command_interval)
@@ -135,13 +179,23 @@ class EmergencyProbe(Node):
         self.send_command(True)
         self.wait_for(lambda state: state.active is True, timeout, "emergency latch active")
 
+    def ensure_latch_active(self, timeout: float) -> None:
+        if self.snapshot.active is True:
+            log_pass("emergency latch already active", self.snapshot)
+            return
+
+        log_warn("emergency latch was already released; latching before continuing", self.snapshot)
+        self.request_latch(timeout)
+
 
 def prompt(message: str) -> None:
-    input(f"\nACTION: {message}\nPress Enter when ready. ")
+    action = colorize("ACTION", "yellow", "bold")
+    prompt_text = colorize("Press Enter when ready.", "bold")
+    input(f"\n{action}: {colorize(message, 'yellow')}\n{prompt_text} ")
 
 
 def print_section(title: str) -> None:
-    print(f"\n=== {title} ===")
+    print(f"\n{colorize(f'=== {title} ===', 'blue', 'bold')}")
 
 
 def wait_for_clear_physical_inputs(probe: EmergencyProbe, timeout: float) -> None:
@@ -152,21 +206,24 @@ def wait_for_clear_physical_inputs(probe: EmergencyProbe, timeout: float) -> Non
     )
 
 
-def test_initial_latch(probe: EmergencyProbe, timeout: float) -> None:
-    print_section("Initial latch")
-    probe.wait_for(lambda state: state.active is True, timeout, "emergency latch active after boot")
+def test_initial_status(probe: EmergencyProbe) -> None:
+    print_section("Initial status")
+    if probe.snapshot.active is True:
+        log_pass("emergency latch active", probe.snapshot)
+    else:
+        log_warn("emergency latch already released; continuing rerunnable test", probe.snapshot)
 
 
 def test_command_confirmation(probe: EmergencyProbe, timeout: float) -> None:
     print_section("Command confirmation")
     wait_for_clear_physical_inputs(probe, timeout)
 
-    probe.wait_for(lambda state: state.active is True, timeout, "emergency latch active before release")
+    probe.ensure_latch_active(timeout)
     probe.send_command(False, count=2)
     probe.spin_for(0.3)
     if probe.snapshot.active is not True:
         raise TestFailure("Emergency latch released after only two release commands")
-    print("PASS: two release commands are not enough")
+    log_pass("two release commands are not enough")
 
     probe.send_command(False, count=1)
     probe.wait_for(lambda state: state.active is False, timeout, "third release command accepted")
@@ -184,7 +241,7 @@ def test_command_window_timeout(probe: EmergencyProbe, timeout: float) -> None:
     probe.spin_for(0.3)
     if probe.snapshot.active is not False:
         raise TestFailure("Emergency latch accepted commands outside the one second window")
-    print("PASS: command confirmation window expires")
+    log_pass("command confirmation window expires")
 
 
 def test_software_latch(probe: EmergencyProbe, timeout: float) -> None:
@@ -197,7 +254,6 @@ def test_software_latch(probe: EmergencyProbe, timeout: float) -> None:
         timeout,
         "software emergency request reported",
     )
-
     probe.release_latch(timeout)
     probe.wait_for(
         lambda state: state.software_requested is False,
@@ -290,14 +346,21 @@ def parse_args() -> argparse.Namespace:
         default=0.2,
         help="Interval between repeated emergency commands",
     )
+    parser.add_argument(
+        "--color",
+        choices=("auto", "always", "never"),
+        default="auto",
+        help="Colorize output: auto, always, or never",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
+    configure_color(args.color)
 
-    print("Interactive OpenMower emergency HIL test")
-    print("Prerequisites:")
+    print(colorize("Interactive OpenMower emergency HIL test", "bold"))
+    print(colorize("Prerequisites:", "bold"))
     print("- Firmware from this branch is flashed on the OpenMower mainboard.")
     print("- micro-ROS agent is running and connected to the firmware.")
     print("- The mower is physically safe to handle.")
@@ -312,7 +375,7 @@ def main() -> int:
         probe.wait_for_initial_messages(args.timeout)
         probe.wait_for_command_subscriber(args.timeout)
 
-        test_initial_latch(probe, args.timeout)
+        test_initial_status(probe)
         test_command_confirmation(probe, args.timeout)
         test_command_window_timeout(probe, args.timeout)
         test_software_latch(probe, args.timeout)
@@ -320,13 +383,13 @@ def main() -> int:
         test_single_lift_input(probe, args.timeout)
         test_double_lift_input(probe, args.timeout)
 
-        print("\nAll emergency HIL checks passed.")
+        print(f"\n{colorize('All emergency HIL checks passed.', 'green', 'bold')}")
         return 0
     except (KeyboardInterrupt, EOFError):
-        print("\nTest interrupted.")
+        print(f"\n{colorize('Test interrupted.', 'yellow', 'bold')}")
         return 130
     except TestFailure as exc:
-        print(f"\nFAIL: {exc}")
+        log_fail(str(exc))
         return 1
     finally:
         probe.destroy_node()

--- a/test/hil/emergency_interactive.py
+++ b/test/hil/emergency_interactive.py
@@ -208,10 +208,10 @@ def wait_for_clear_physical_inputs(probe: EmergencyProbe, timeout: float) -> Non
 
 def test_initial_status(probe: EmergencyProbe) -> None:
     print_section("Initial status")
-    if probe.snapshot.active is True:
-        log_pass("emergency latch active", probe.snapshot)
+    if probe.snapshot.active is False:
+        log_pass("emergency latch inactive after boot", probe.snapshot)
     else:
-        log_warn("emergency latch already released; continuing rerunnable test", probe.snapshot)
+        log_warn("emergency latch already active; continuing rerunnable test", probe.snapshot)
 
 
 def test_command_confirmation(probe: EmergencyProbe, timeout: float) -> None:

--- a/test/hil/emergency_interactive.py
+++ b/test/hil/emergency_interactive.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Interactive hardware-in-the-loop emergency test.
+
+This test expects real OpenMower hardware, flashed firmware, and a running
+micro-ROS agent. It guides the operator through physical emergency inputs and
+verifies the ROS 2 emergency API exposed by the firmware.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import Bool, UInt8
+
+
+class TestFailure(RuntimeError):
+    pass
+
+
+@dataclass
+class EmergencySnapshot:
+    active: Optional[bool] = None
+    stop_active: Optional[bool] = None
+    lift_active: Optional[bool] = None
+    tilt_active: Optional[bool] = None
+    software_requested: Optional[bool] = None
+    release_blocked: Optional[bool] = None
+    lifted_wheels: Optional[int] = None
+
+    def is_complete(self) -> bool:
+        return all(value is not None for value in self.__dict__.values())
+
+    def physical_inputs_clear(self) -> bool:
+        return (
+            self.stop_active is False
+            and self.lift_active is False
+            and self.tilt_active is False
+            and self.lifted_wheels == 0
+        )
+
+    def format(self) -> str:
+        return (
+            f"active={self.active} "
+            f"stop={self.stop_active} "
+            f"lift={self.lift_active} "
+            f"tilt={self.tilt_active} "
+            f"software={self.software_requested} "
+            f"release_blocked={self.release_blocked} "
+            f"lifted_wheels={self.lifted_wheels}"
+        )
+
+
+class EmergencyProbe(Node):
+    def __init__(self, command_interval: float):
+        super().__init__("emergency_hil_test")
+        self.snapshot = EmergencySnapshot()
+        self.command_interval = command_interval
+        self._subscriptions = []
+        self.command_publisher = self.create_publisher(Bool, "emergency/command", 10)
+
+        self._subscribe_bool("emergency/active", "active")
+        self._subscribe_bool("emergency/stop_active", "stop_active")
+        self._subscribe_bool("emergency/lift_active", "lift_active")
+        self._subscribe_bool("emergency/tilt_active", "tilt_active")
+        self._subscribe_bool("emergency/software_requested", "software_requested")
+        self._subscribe_bool("emergency/release_blocked", "release_blocked")
+        self._subscriptions.append(
+            self.create_subscription(UInt8, "emergency/lifted_wheels", self._lifted_wheels_cb, 10)
+        )
+
+    def _subscribe_bool(self, topic: str, field: str) -> None:
+        self._subscriptions.append(
+            self.create_subscription(Bool, topic, lambda msg, field=field: self._set(field, msg.data), 10)
+        )
+
+    def _lifted_wheels_cb(self, msg: UInt8) -> None:
+        self.snapshot.lifted_wheels = int(msg.data)
+
+    def _set(self, field: str, value: bool) -> None:
+        setattr(self.snapshot, field, bool(value))
+
+    def spin_for(self, duration: float) -> None:
+        deadline = time.monotonic() + duration
+        while time.monotonic() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.05)
+
+    def wait_for(
+        self,
+        predicate: Callable[[EmergencySnapshot], bool],
+        timeout: float,
+        description: str,
+    ) -> EmergencySnapshot:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.05)
+            if predicate(self.snapshot):
+                print(f"PASS: {description}")
+                print(f"      {self.snapshot.format()}")
+                return self.snapshot
+
+        raise TestFailure(f"Timeout waiting for {description}. Last state: {self.snapshot.format()}")
+
+    def wait_for_initial_messages(self, timeout: float) -> None:
+        self.wait_for(lambda state: state.is_complete(), timeout, "all emergency topics")
+
+    def wait_for_command_subscriber(self, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.05)
+            if self.command_publisher.get_subscription_count() > 0:
+                print("PASS: emergency command subscriber discovered")
+                return
+
+        raise TestFailure("No subscriber discovered for emergency/command")
+
+    def send_command(self, value: bool, count: int = 3) -> None:
+        msg = Bool()
+        msg.data = value
+        print(f"Publishing emergency/command={value} {count} time(s)")
+        for _ in range(count):
+            self.command_publisher.publish(msg)
+            self.spin_for(self.command_interval)
+
+    def release_latch(self, timeout: float) -> None:
+        self.send_command(False)
+        self.wait_for(lambda state: state.active is False, timeout, "emergency latch released")
+
+    def request_latch(self, timeout: float) -> None:
+        self.send_command(True)
+        self.wait_for(lambda state: state.active is True, timeout, "emergency latch active")
+
+
+def prompt(message: str) -> None:
+    input(f"\nACTION: {message}\nPress Enter when ready. ")
+
+
+def print_section(title: str) -> None:
+    print(f"\n=== {title} ===")
+
+
+def wait_for_clear_physical_inputs(probe: EmergencyProbe, timeout: float) -> None:
+    probe.wait_for(
+        lambda state: state.physical_inputs_clear(),
+        timeout,
+        "all physical emergency inputs clear",
+    )
+
+
+def test_initial_latch(probe: EmergencyProbe, timeout: float) -> None:
+    print_section("Initial latch")
+    probe.wait_for(lambda state: state.active is True, timeout, "emergency latch active after boot")
+
+
+def test_command_confirmation(probe: EmergencyProbe, timeout: float) -> None:
+    print_section("Command confirmation")
+    wait_for_clear_physical_inputs(probe, timeout)
+
+    probe.wait_for(lambda state: state.active is True, timeout, "emergency latch active before release")
+    probe.send_command(False, count=2)
+    probe.spin_for(0.3)
+    if probe.snapshot.active is not True:
+        raise TestFailure("Emergency latch released after only two release commands")
+    print("PASS: two release commands are not enough")
+
+    probe.send_command(False, count=1)
+    probe.wait_for(lambda state: state.active is False, timeout, "third release command accepted")
+
+
+def test_command_window_timeout(probe: EmergencyProbe, timeout: float) -> None:
+    print_section("Command window timeout")
+    wait_for_clear_physical_inputs(probe, timeout)
+    if probe.snapshot.active is True:
+        probe.release_latch(timeout)
+
+    probe.send_command(True, count=2)
+    probe.spin_for(1.2)
+    probe.send_command(True, count=1)
+    probe.spin_for(0.3)
+    if probe.snapshot.active is not False:
+        raise TestFailure("Emergency latch accepted commands outside the one second window")
+    print("PASS: command confirmation window expires")
+
+
+def test_software_latch(probe: EmergencyProbe, timeout: float) -> None:
+    print_section("Software latch")
+    wait_for_clear_physical_inputs(probe, timeout)
+
+    probe.request_latch(timeout)
+    probe.wait_for(
+        lambda state: state.software_requested is True,
+        timeout,
+        "software emergency request reported",
+    )
+
+    probe.release_latch(timeout)
+    probe.wait_for(
+        lambda state: state.software_requested is False,
+        timeout,
+        "software emergency request cleared",
+    )
+
+
+def test_stop_input(probe: EmergencyProbe, timeout: float) -> None:
+    print_section("STOP input")
+    wait_for_clear_physical_inputs(probe, timeout)
+    if probe.snapshot.active is True:
+        probe.release_latch(timeout)
+
+    prompt("Press and hold STOP")
+    probe.wait_for(
+        lambda state: state.stop_active is True and state.active is True,
+        timeout,
+        "STOP input latches emergency",
+    )
+
+    probe.send_command(False)
+    probe.wait_for(
+        lambda state: state.active is True and state.release_blocked is True,
+        timeout,
+        "release blocked while STOP is held",
+    )
+
+    prompt("Release STOP")
+    probe.wait_for(
+        lambda state: state.stop_active is False and state.release_blocked is False,
+        timeout,
+        "STOP input released",
+    )
+    probe.release_latch(timeout)
+
+
+def test_single_lift_input(probe: EmergencyProbe, timeout: float) -> None:
+    print_section("Single lift / tilt input")
+    wait_for_clear_physical_inputs(probe, timeout)
+    if probe.snapshot.active is True:
+        probe.release_latch(timeout)
+
+    prompt("Activate exactly one lift sensor and hold it")
+    probe.wait_for(
+        lambda state: state.lifted_wheels == 1,
+        timeout,
+        "one lift sensor detected",
+    )
+    probe.wait_for(
+        lambda state: state.tilt_active is True and state.active is True,
+        max(timeout, 4.0),
+        "single lift becomes tilt emergency",
+    )
+
+    prompt("Release the lift sensor")
+    wait_for_clear_physical_inputs(probe, timeout)
+    probe.release_latch(timeout)
+
+
+def test_double_lift_input(probe: EmergencyProbe, timeout: float) -> None:
+    print_section("Double lift input")
+    wait_for_clear_physical_inputs(probe, timeout)
+    if probe.snapshot.active is True:
+        probe.release_latch(timeout)
+
+    prompt("Activate two lift sensors at the same time and hold them")
+    probe.wait_for(
+        lambda state: state.lifted_wheels == 2,
+        timeout,
+        "two lift sensors detected",
+    )
+    probe.wait_for(
+        lambda state: state.lift_active is True and state.active is True,
+        timeout,
+        "double lift latches emergency",
+    )
+
+    prompt("Release both lift sensors")
+    wait_for_clear_physical_inputs(probe, timeout)
+    probe.release_latch(timeout)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--timeout", type=float, default=10.0, help="Timeout for each wait step")
+    parser.add_argument(
+        "--command-interval",
+        type=float,
+        default=0.2,
+        help="Interval between repeated emergency commands",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    print("Interactive OpenMower emergency HIL test")
+    print("Prerequisites:")
+    print("- Firmware from this branch is flashed on the OpenMower mainboard.")
+    print("- micro-ROS agent is running and connected to the firmware.")
+    print("- The mower is physically safe to handle.")
+    print("- You can press STOP and activate one or two lift sensors on demand.")
+    prompt("Confirm prerequisites")
+
+    rclpy.init()
+    probe = EmergencyProbe(args.command_interval)
+
+    try:
+        print_section("ROS connectivity")
+        probe.wait_for_initial_messages(args.timeout)
+        probe.wait_for_command_subscriber(args.timeout)
+
+        test_initial_latch(probe, args.timeout)
+        test_command_confirmation(probe, args.timeout)
+        test_command_window_timeout(probe, args.timeout)
+        test_software_latch(probe, args.timeout)
+        test_stop_input(probe, args.timeout)
+        test_single_lift_input(probe, args.timeout)
+        test_double_lift_input(probe, args.timeout)
+
+        print("\nAll emergency HIL checks passed.")
+        return 0
+    except (KeyboardInterrupt, EOFError):
+        print("\nTest interrupted.")
+        return 130
+    except TestFailure as exc:
+        print(f"\nFAIL: {exc}")
+        return 1
+    finally:
+        probe.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/remote-openocd.sh
+++ b/utils/remote-openocd.sh
@@ -32,16 +32,22 @@ if ! groups | grep -q "gpio"; then
     exit 1
 fi
 
-if ! command -v /usr/local/bin/openocd &>/dev/null; then
-    echo "openocd could not be found, installing it now..."
+function openocdSupportsLinuxGpiod() {
+    command -v /usr/local/bin/openocd &>/dev/null && \
+        /usr/local/bin/openocd -c "adapter driver linuxgpiod" -c "exit" &>/dev/null
+}
+
+if ! openocdSupportsLinuxGpiod; then
+    echo "openocd with linuxgpiod support could not be found, installing it now..."
 
     sudo apt-get update >/dev/null
-    sudo apt-get install -y libtool libjim-dev
+    sudo apt-get install -y libtool libjim-dev libgpiod-dev pkg-config
 
-    git clone git@github.com:openocd-org/openocd.git
+    rm -rf openocd
+    git clone https://github.com/openocd-org/openocd.git
     cd openocd
     ./bootstrap
-    ./configure --disable-werror
+    ./configure --disable-werror --enable-linuxgpiod
     make -j4
     sudo make install
 fi


### PR DESCRIPTION
## Summary
- add OpenMower-style emergency state handling for HW 0.13.x hall inputs
- publish individual emergency ROS 2 status topics at 10 Hz
- add `emergency/command` latch/release topic requiring 3 matching commands within 1 second
- add priority blinking red emergency LED status
- safely initialize `PIN_ESC_SHUTDOWN` LOW without dynamic shutdown logic
- add interactive ROS 2 HIL emergency test for real hardware validation

## Verification
- `/home/jkaflik/.platformio/penv/bin/pio run`
- `python3 -m py_compile test/hil/emergency_interactive.py`

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Emergency mode system with latching control triggered by stop, lift, and tilt inputs
  * Emergency status LED indicator displaying red blinking with priority over normal status
  * Emergency ROS API including status monitoring topic and software command interface

* **Documentation**
  * Updated README documenting emergency mode features, LED status behavior, and testing procedures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jkaflik/omros2-firmware/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->